### PR TITLE
fix: make it work on IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.1.0",
     "@types/jest": "^23.3.1",
     "ajv": "^6.5.3",
     "babel-core": "^6.26.3",

--- a/src/Map.js
+++ b/src/Map.js
@@ -2,11 +2,11 @@
 
 require('./style.css');
 const objectAssign = require('object-assign');
-const {isHTMLElement} = require('./utils/dom');
+const dom = require('./utils/dom');
 
 class Map {
     constructor(domSelector, apiKey, locale, options, plugins, customWindow) {
-        this.domElement = isHTMLElement(domSelector) ? domSelector : document.querySelector(domSelector);
+        this.domElement = dom.isHTMLElement(domSelector) ? domSelector : document.querySelector(domSelector);
         this.domId = this.domElement.id || '';
         this.apiKey = apiKey;
         this.locale = locale || 'en';

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -2,6 +2,7 @@
 
 let ieUtils = require('./ie');
 let isAString = require('./type').isAString;
+let isDefined = require('simple-js-validator').isDefined;
 
 module.exports = {
     addScript: function (domElement, src) {
@@ -58,13 +59,8 @@ module.exports = {
         div.innerHTML = str;
         let textContent = div.textContent || div.innerText || "";
         let classes = '';
-        try {
-            if (isObject(div.firstChild) && isObject(div.firstChild.classList)) {
-                classes = div.firstChild.classList.value;
-            }
-        } catch (e) {
-            // may fail with Cannot read property 'classList' of null
-            // intentionally do nothing
+        if (isDefined(div.firstChild)) {
+            classes = div.firstChild.className;
         }
         return {textContent: textContent, classes: classes};
     },
@@ -83,10 +79,6 @@ module.exports = {
         return result;
     })
 };
-
-function isObject(element) {
-    return typeof element === 'object';
-}
 
 function extractPx(str) {
     if (true === isAString(str)) {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -57,7 +57,7 @@ module.exports = {
     extractTextAndCssClasses: function (str) {
         let div = document.createElement('div');
         div.innerHTML = str;
-        let textContent = div.textContent || div.innerText || "";
+        let textContent = div.textContent || div.innerText || '';
         let classes = '';
         if (isDefined(div.firstChild)) {
             classes = div.firstChild.className;

--- a/test/providers/googleMap/test_content/index.html
+++ b/test/providers/googleMap/test_content/index.html
@@ -17,8 +17,8 @@
 <h3>My Google Maps Demo</h3>
 <!--The div element for the map -->
 <div id="map"></div>
-<script src="/googleMap.js"></script>
-<script src="/map.js"></script>
+<script type="text/javascript" src="/googleMap.js"></script>
+<script type="text/javascript" src="/map.js"></script>
 <script>
     function onLoad() {
         new MappedMap("map").init();

--- a/test/utils/dom.spec.js
+++ b/test/utils/dom.spec.js
@@ -10,7 +10,7 @@ test('extract text from text', ()=>{
 });
 
 test('extract no css class from text', () => {
-    expect(dom.extractTextAndCssClasses('a content').classes).toEqual('');
+    expect(dom.extractTextAndCssClasses('a content').classes).toBeUndefined();
 });
 
 test('extract text from html', ()=>{
@@ -26,7 +26,13 @@ test('extract css classes from fragment', ()=>{
 });
 
 test('extract no css class from text', ()=>{
-    expect(dom.extractTextAndCssClasses('a content').classes).toEqual('');
+    expect(dom.extractTextAndCssClasses('a content').classes).toBeUndefined();
+});
+
+test('extract no css class and no text from empty string', () => {
+    const textAndCssClasses = dom.extractTextAndCssClasses('');
+    expect(textAndCssClasses.textContent).toEqual('');
+    expect(textAndCssClasses.classes).toEqual('');
 });
 
 test('extract style from css class', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,10 @@ module.exports = {
             {
                 test:/\.js$/,
                 exclude: /node_modules/,
-                loader: 'babel-loader'
+                loader: 'babel-loader',
+                options: {
+                    presets: ['@babel/preset-env']
+                }
             },
             {
                 test:/\.css$/,


### PR DESCRIPTION
add build configuration with babel to transpile js to ES5 in order to
run on IE
fix extraction of text and css classes from html fragment