### PR TITLE
chore(update-dependencies): mappy 7.5.0 and leaflet 1.0.3

### DIFF
--- a/src/providers/mappy/Map.js
+++ b/src/providers/mappy/Map.js
@@ -6,7 +6,7 @@ class Map extends L.Mappy.Map {
     constructor(domElement, options) {
         const defaultOptions = {
             logoControl: {
-                dir: '//d11lbkprc85eyb.cloudfront.net/Mappy/images/'
+                dir: '//d11lbkprc85eyb.cloudfront.net/Mappy/7.5.0/images/'
             }
         };
 

--- a/src/providers/mappy/Mappy.js
+++ b/src/providers/mappy/Mappy.js
@@ -52,18 +52,18 @@ class Mappy extends Map {
         }
 
         domUtils.addResources(document.body, [
-            domUtils.createScript('//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.1/leaflet.js'),
-            domUtils.createStyle('//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.1/leaflet.css')
+            domUtils.createStyle('//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css'),
+            domUtils.createScript('//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js')
         ], () => {
             const resources = [
-                domUtils.createScript('//d11lbkprc85eyb.cloudfront.net/Mappy/5.4.1/L.Mappy.js'),
-                domUtils.createStyle('//d11lbkprc85eyb.cloudfront.net/Mappy/5.4.1/L.Mappy.css')
+                domUtils.createScript('//d11lbkprc85eyb.cloudfront.net/Mappy/7.5.0/L.Mappy.js'),
+                domUtils.createStyle('//d11lbkprc85eyb.cloudfront.net/Mappy/7.5.0/L.Mappy.css')
             ];
 
             if (this.plugins.clusterer) {
-                resources.push(domUtils.createScript('//d11lbkprc85eyb.cloudfront.net/plugins/mappy/5.4.1/leaflet.markercluster.js'));
-                resources.push(domUtils.createStyle('//d11lbkprc85eyb.cloudfront.net/plugins/mappy/5.4.1/MarkerCluster.Default.css'));
-                resources.push(domUtils.createStyle('//d11lbkprc85eyb.cloudfront.net/plugins/mappy/5.4.1/MarkerCluster.css'));
+                resources.push(domUtils.createScript('//d11lbkprc85eyb.cloudfront.net/plugins/mappy/7.5.0/leaflet.markercluster.js'));
+                resources.push(domUtils.createStyle('//d11lbkprc85eyb.cloudfront.net/plugins/mappy/7.5.0/MarkerCluster.Default.css'));
+                resources.push(domUtils.createStyle('//d11lbkprc85eyb.cloudfront.net/plugins/mappy/7.5.0/MarkerCluster.css'));
             }
 
             domUtils.addResources(document.body, resources, () => {


### PR DESCRIPTION
Mappy is now deprecating old versions including the version used in production in Leadformance frontends (5.4.1).
This will update to the latest Mappy frontend scripts version, and the most recent compatible version of leaflet (1.0.3 instead of a more recent version because Mappy is incompatible with them).