### PR TITLE
fix: rename Map to avoid js conflict

### DIFF
--- a/src/AbstractMap.js
+++ b/src/AbstractMap.js
@@ -4,7 +4,7 @@ require('./style.css');
 const objectAssign = require('object-assign');
 const dom = require('./utils/dom');
 
-class Map {
+class AbstractMap {
     constructor(domSelector, apiKey, locale, options, plugins, customWindow) {
         this.domElement = dom.isHTMLElement(domSelector) ? domSelector : document.querySelector(domSelector);
         this.domId = this.domElement.id || '';
@@ -77,4 +77,4 @@ class Map {
     }
 }
 
-module.exports = Map;
+module.exports = AbstractMap;

--- a/src/providers/baidu/Baidu.js
+++ b/src/providers/baidu/Baidu.js
@@ -7,7 +7,7 @@
  */
 
 /*jshint -W079 */
-let Map = require('../../Map');
+let AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 let domUtils = require('../../utils/dom');
@@ -19,7 +19,7 @@ let BaiduMap;
 
 let directionsService;
 
-class Baidu extends Map {
+class Baidu extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -72,7 +72,7 @@ class Baidu extends Map {
 
         window._baiduCallbackOnLoad = function() {
             // Require baidu object here cause they're not loaded before
-            BaiduMap = require('./Map');
+            BaiduMap = require('./BaiduMap');
             Marker = require('./Marker');
 
             ieUtils.delete(window, '_baiduCallbackOnLoad');
@@ -121,5 +121,5 @@ class Baidu extends Map {
     }
 }
 
-window.Map = Baidu;
+window.BaiduMap = Baidu;
 window.OneMap = Baidu;

--- a/src/providers/baidu/BaiduMap.js
+++ b/src/providers/baidu/BaiduMap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class Map extends BMap.Map {
+class BaiduMap extends BMap.Map {
     constructor(domElement, options) {
         super(domElement, options);
 
@@ -16,4 +16,4 @@ class Map extends BMap.Map {
     }
 }
 
-module.exports = Map;
+module.exports = BaiduMap;

--- a/src/providers/bingMap/bingMap.js
+++ b/src/providers/bingMap/bingMap.js
@@ -6,7 +6,7 @@
  */
 
 /*jshint -W079 */
-let Map = require('../../Map');
+let AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 let domUtils = require('../../utils/dom');
@@ -20,7 +20,7 @@ let MarkerClusterer;
 
 let directionsService;
 
-class BingMap extends Map {
+class BingMap extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -167,5 +167,5 @@ class BingMap extends Map {
     }
 }
 
-window.Map = BingMap;
+window.BingMap = BingMap;
 window.OneMap = BingMap;

--- a/src/providers/googleMap/googleMap.js
+++ b/src/providers/googleMap/googleMap.js
@@ -6,7 +6,7 @@
  */
 
 /*jshint -W079 */
-let Map = require('../../Map');
+let AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 let domUtils = require('../../utils/dom');
@@ -16,7 +16,7 @@ let objectAssign = require('object-assign');
 let InfoWindow;
 let Marker;
 
-class GoogleMap extends Map {
+class GoogleMap extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -251,5 +251,5 @@ class GoogleMap extends Map {
     }
 }
 
-window.Map = GoogleMap;
+window.GoogleMap = GoogleMap;
 window.OneMap = GoogleMap;

--- a/src/providers/mappy/Mappy.js
+++ b/src/providers/mappy/Mappy.js
@@ -6,7 +6,7 @@
  */
 
 /*jshint -W079 */
-const Map = require('../../Map');
+const AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 const domUtils = require('../../utils/dom');
@@ -15,7 +15,7 @@ const loaderUtils = require('../../utils/loader');
 let MappyMap;
 let Marker;
 
-class Mappy extends Map {
+class Mappy extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -67,7 +67,7 @@ class Mappy extends Map {
             }
 
             domUtils.addResources(document.body, resources, () => {
-                MappyMap = require('./Map');
+                MappyMap = require('./MappyMap');
                 Marker = require('./Marker');
 
                 callback();
@@ -143,5 +143,5 @@ class Mappy extends Map {
     }
 }
 
-window.Map = Mappy;
+window.MappyMap = Mappy;
 window.OneMap = Mappy;

--- a/src/providers/mappy/MappyMap.js
+++ b/src/providers/mappy/MappyMap.js
@@ -2,7 +2,7 @@
 
 const objectAssign = require('object-assign');
 
-class Map extends L.Mappy.Map {
+class MappyMap extends L.Mappy.Map {
     constructor(domElement, options) {
         const defaultOptions = {
             logoControl: {
@@ -17,4 +17,4 @@ class Map extends L.Mappy.Map {
     }
 }
 
-module.exports = Map;
+module.exports = MappyMap;

--- a/src/providers/openStreetMap/openStreetMap.js
+++ b/src/providers/openStreetMap/openStreetMap.js
@@ -6,13 +6,13 @@
  */
 
 /*jshint -W079 */
-let Map = require('../../Map');
+let AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 let domUtils = require('../../utils/dom');
 let _ = require('lodash');
 
-class OpenStreetMap extends Map {
+class OpenStreetMap extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -193,5 +193,5 @@ class OpenStreetMap extends Map {
     }
 }
 
-window.Map = OpenStreetMap;
+window.OpenStreetMap = OpenStreetMap;
 window.OneMap = OpenStreetMap;

--- a/src/providers/viaMichelin/ViaMichelin.js
+++ b/src/providers/viaMichelin/ViaMichelin.js
@@ -6,7 +6,7 @@
  */
 
 /*jshint -W079 */
-let Map = require('../../Map');
+let AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 let domUtils = require('../../utils/dom');
@@ -19,7 +19,7 @@ let markerClusterer;
 let directionsService;
 let vmService;
 
-class ViaMichelinMap extends Map {
+class ViaMichelinMap extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -217,5 +217,5 @@ function getLargestBounds(bounds, point) {
     ];
 }
 
-window.Map = ViaMichelinMap;
+window.ViaMichelinMap = ViaMichelinMap;
 window.OneMap = ViaMichelinMap;

--- a/src/providers/yandex/Yandex.js
+++ b/src/providers/yandex/Yandex.js
@@ -6,7 +6,7 @@
  */
 
 /*jshint -W079 */
-let Map = require('../../Map');
+let AbstractMap = require('../../AbstractMap');
 /* jshint +W079 */
 
 let domUtils = require('../../utils/dom');
@@ -18,7 +18,7 @@ let YandexMap;
 
 let directionsService;
 
-class Yandex extends Map {
+class Yandex extends AbstractMap {
     constructor(...args) {
         super(...args);
 
@@ -73,7 +73,7 @@ class Yandex extends Map {
 
         window._yandexCallbackOnLoad = function() {
             // Require yandex object here cause they're not loaded before
-            YandexMap = require('./Map');
+            YandexMap = require('./YandexMap');
             Marker = require('./Marker');
 
             ieUtils.delete(window, '_yandexCallbackOnLoad');
@@ -137,5 +137,5 @@ function getLargestBounds(bounds, point) {
     ];
 }
 
-window.Map = Yandex;
+window.YandexMap = Yandex;
 window.OneMap = Yandex;

--- a/src/providers/yandex/YandexMap.js
+++ b/src/providers/yandex/YandexMap.js
@@ -2,7 +2,7 @@
 
 let objectAssign = require('object-assign');
 
-class Map extends ymaps.Map {
+class YandexMap extends ymaps.Map {
     constructor(domElement, options) {
         let defaultOptions = {
             center: [0, 0],
@@ -13,4 +13,4 @@ class Map extends ymaps.Map {
     }
 }
 
-module.exports = Map;
+module.exports = YandexMap;

--- a/test/providers/googleMap/test_content/map.js.tst_template
+++ b/test/providers/googleMap/test_content/map.js.tst_template
@@ -6,7 +6,7 @@ class MappedMap {
     }
 
     init() {
-        this.map = new window.Map(`#map`, this.attr.apiKey, this.attr.locale, {}, {clusterer: true});
+        this.map = new window.OneMap(`#map`, this.attr.apiKey, this.attr.locale, {}, {clusterer: true});
         this.displayMap();
     }
 


### PR DESCRIPTION
Zendesk: https://leadformance.zendesk.com/agent/tickets/22364

We have to remove the use of the word `Map` who is used by JS in `ES6`