### PR TITLE
fix: use global method instead of Numbers ones for IE

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -83,8 +83,8 @@ module.exports = {
 function extractPx(str) {
     if (true === isAString(str)) {
         const pxValue = str.replace('px', '').replace('"', '');
-        const pxNumber = Number.parseInt(pxValue);
-        return Number.isFinite(pxNumber) ? pxNumber : 0;
+        const pxNumber = parseInt(pxValue);
+        return isFinite(pxNumber) ? pxNumber : 0;
     } else {
         return 0;
     }


### PR DESCRIPTION
Trello: https://trello.com/c/vq0Og5gW/1593-validation-nom-de-domaine-map-ko-sur-ie

`Number.parseInt()` doesn't work on IE, but `parseInt()` yes.